### PR TITLE
Feature: Open tab next to current

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -9,10 +9,15 @@ browser.contextMenus.create({
 });
 browser.contextMenus.onClicked.addListener((info, tab) => {
 	if (info.menuItemId === "open-in-bundle-viewer") {
-		const url = "https://bundleviewer.octoprint.org/?url=" + encodeURIComponent(info.linkUrl)
-		let newTab = browser.tabs.create({
-			active: true,
-			url: url
-		})
+		browser.tabs.query({ active: true, windowId: browser.windows.WINDOW_ID_CURRENT })
+			.then(tabs => browser.tabs.get(tabs[0].id))
+			.then(currentTab => {
+				const url = "https://bundleviewer.octoprint.org/?url=" + encodeURIComponent(info.linkUrl)
+				let newTab = browser.tabs.create({
+					active: true,
+					index: currentTab.index + 1,
+					url: url
+				})
+			})
 	}
 });


### PR DESCRIPTION
I can have quite a number of tabs open during a issue triage session. It would be nice if bundleviewer links opened right next to the tab I selected the link on by default, instead of at the end of the whole tab list (or whatever the browser defaults to).